### PR TITLE
Schema 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ name: System Name
 ## Component YAML
 ```yaml
 name: Name of the component
+key: Key of the component (defaults to the filename if not present)
 documentation_complete: Manual check if the documentation is complete (for gap analysis)
 references:
   - name: Name of the reference ie. EC2 website

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Schemas version 1.0
+# Schemas version 2.0
 YAML schema, examples, and validators for OpenControl format.
 
 ## Example Project Organizations
@@ -34,24 +34,24 @@ references:
     path: Relative path of local file or URL ie. diagrams/diagram-1.png
     type: Type of reference ie. Image, URL
 verifications:
-  ID_of_verification:  
+  - key: Key of verification
     name: Name of verification
     path: Relative path of local file or URL ie. diagrams/diagram-1.png
     type: Type of reference ie. Image, URL
-  EC2_Verification_2:
+  - key: Key of verification
     name: Name of verification
     path: Relative path of local file or URL ie. diagrams/diagram-1.png
     type: Type of reference ie. Image, URL
 satisfies:
-  NIST-800-53:
-    CM-2:
-      narrative: Justification text
-      implementation_status: Manual status of implementation (for gap analysis)
-      references:
-        - verification: The specific verification ID that the reference links, no component or system is needed for internal references
-        - system: System name of the verification (can link to other systems / components)
-          component: System name of the verification (can link to other systems / components)
-          verification: The specific verification ID that the reference links to
+  - standard_key: Standard Key (NIST-800-53)
+    control_key: Control Key (CM-2)
+    narrative: Justification text
+    implementation_status: Manual status of implementation (for gap analysis)
+    covered_by:
+      - verification_key: The specific verification ID that the reference links, no component or system is needed for internal references
+      - system_key: System name of the verification (can link to other systems / components)
+        component_key: System name of the verification (can link to other systems / components)
+        verification_key: The specific verification ID that the reference links to
 ```
 
 ## Standards Documentation

--- a/component-example.yaml
+++ b/component-example.yaml
@@ -1,0 +1,29 @@
+name: Test Component # Name of the component
+key: test # Key of the component (defaults to the filename if not present)
+documentation_complete: true # Manual check if the documentation is complete (for gap analysis)
+references:
+  - name: EC2 Diagram # Name of the reference
+    path: diagrams/diagram-1.png # Relative path of local file or URL ie. diagrams/diagram-1.png
+    type: Image # Type of reference ie. Image, URL
+  - name: EC2 Diagram 2 # Name of the reference
+    path: diagrams/diagram-2.png # Relative path of local file or URL ie. diagrams/diagram-1.png
+    type: Image # Type of reference ie. Image, URL
+verifications:
+  - key: test_verification_1 # Key of verification
+    name: TEST 1 # Name of verification
+    path: diagrams/diagram-1.png # Relative path of local file or URL ie.
+    type: Image # Type of reference ie. Image, URL
+  - key: test_verification_2 # Key of verification
+    name: TEST 1 # Name of verification
+    path: diagrams/diagram-2.png # Relative path of local file or URL ie.
+    type: Image # Type of reference ie. Image, URL
+satisfies:
+  - standard_key: NIST-800-53 # Standard Key
+    control_key: CM-2 # Control Key
+    narrative: Text ... # Justification text
+    implementation_status: partial # Manual status of implementation (for gap analysis)
+    covered_by:
+      - verification_key: test_verification_1 #The specific verification ID that the reference links, no component or system is needed for internal references
+      - system_key: other_system # System name of the verification (can link to other systems / components)
+        component_key: other_component # System name of the verification (can link to other systems / components)
+        verification_key: other_key # The specific verification ID that the reference links to

--- a/opencontrol-component-json-schema.json
+++ b/opencontrol-component-json-schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "documentation_complete": {
+      "title": "documentation_complete",
+      "type": "boolean"
+    },
+    "references": {
+      "title": "References",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        }
+      },
+      "additionalItems": false
+    },
+    "verifications": {
+      "title": "Verifications",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "title": "Key",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "covered_by": {
+      "title": "Covered By",
+      "type": "array",
+      "items": {
+        "properties": {
+          "standard_key":{
+            "title": "Standard Key",
+            "type": "string"
+          },
+          "control_key":{
+            "title": "Control Key",
+            "type": "string"
+          },
+          "narrative": {
+            "title": "Narrative",
+            "type": "string"
+          },
+          "implementation_status": {
+            "title": "Implementation Status",
+            "type": "string",
+            "enum": [
+              "complete",
+              "partial",
+              "planned"
+            ]
+          },
+          "covered_by": {
+            "title": "Covered By",
+            "type": "array",
+            "items": {
+              "properties": {
+                "verification_key": {
+                  "title": "Verification Key",
+                  "type": "string"
+                },
+                "system_key": {
+                  "title": "System Key",
+                  "type": "string"
+                },
+                "component_key": {
+                  "title": "Component Key",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/opencontrol-component-kwalify-schema.yaml
+++ b/opencontrol-component-kwalify-schema.yaml
@@ -1,0 +1,67 @@
+type: map
+mapping:
+  name:
+    type: str
+    required: True
+  key:
+    type: str
+  documentation_complete:
+    type: bool
+  references:
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          name:
+            type: str
+            required: True
+          path:
+            type: str
+          type:
+            type: str
+            required: True
+  verifications:
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          key:
+            type: str
+            required: True
+          name:
+            type: str
+            required: True
+          path:
+            type: str
+          type:
+            type: str
+            required: True
+  satisfies:
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          standard_key:
+            type: str
+            required: True
+          control_key:
+            type: str
+            required: True
+          narrative:
+            type: str
+            required: True
+          implementation_status:
+            type: str
+            enum: ['partial', 'complete', 'planned']
+          covered_by:
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  system_key:
+                    type: str
+                  component_key:
+                    type: str
+                  verification_key:
+                    type: str
+                    required: True

--- a/transformation-scripts/utils.py
+++ b/transformation-scripts/utils.py
@@ -1,0 +1,15 @@
+""" These are shared functions between v2_to_v1 and v1_to_v2 """
+
+UNCHANGED_FIELDS = ['name', 'documentation_complete', 'references']
+
+
+def add_if_exists(new_data, old_data, field):
+    """ Adds the field to the new data if it exists in the old data """
+    if field in old_data:
+        new_data[field] = old_data.get(field)
+
+
+def transport_usable_data(new_data, old_data):
+    """ Adds the data structures that haven't changed to the new dictionary """
+    for field in UNCHANGED_FIELDS:
+        add_if_exists(new_data=new_data, old_data=old_data, field=field)

--- a/transformation-scripts/v1_example.yaml
+++ b/transformation-scripts/v1_example.yaml
@@ -1,0 +1,40 @@
+name: Amazon Elastic Compute Cloud # Name of the component
+documentation_complete: false # Manual check if the documentation is complete (for gap analysis)
+references:
+  - name: Reference  # Name of the reference ie. EC2 website
+    path: http://VerificationURL.com  # Url of the reference
+    type: URL # type of reference (will affect how it's rendered in the documentation)
+verifications:
+  EC2_Verification_1: # ID of verification
+    name: EC2 Verification 1  # Name of verification
+    path: http://VerificationURL.com #  URL of the verification
+    type: URL # type of reference (will affect how it's rendered in the documentation)
+  EC2_Verification_2:
+    name: EC2 Governor 2
+    path: artifact-ec2-1.png
+    type: Image
+satisfies:
+  NIST-800-53:
+    CM-2:
+      narrative: Justification in narrative form # Justification text
+      implementation_status: partial # Manual status of implementation (for gap analysis)
+      references:
+        - verification: EC2_Verification_1 # The specific verification ID that the reference links, no component or system is needed for internal references
+        - system: CloudFoundry  # System name of the verification (can link to other systems / components)
+          component: UAA  # System name of the verification (can link to other systems / components)
+          verification: UAA_Verification_1 # The specific verification ID that the reference links to
+  PCI-DSS-MAY-2015:
+    1.1:
+      narrative: Justification in narrative form # Justification text
+      implementation_status: partial # Manual status of implementation (for gap analysis)
+      references:
+        - verification: EC2_Verification_1 # The specific verification ID that the reference links, no component or system is needed for internal references
+        - system: CloudFoundry  # System name of the verification (can link to other systems / components)
+          component: UAA  # System name of the verification (can link to other systems / components)
+          verification: UAA_Verification_1 # The specific verification ID that the reference links to
+    1.1.1:
+      narrative: Justification in narrative form # Justification text
+      implementation_status: partial # Manual status of implementation (for gap analysis)
+    2.1:
+      narrative: Justification in narrative form # Justification text
+      implementation_status: partial # Manual status of implementation (for gap analysis)

--- a/transformation-scripts/v1_from_v2_example.yaml
+++ b/transformation-scripts/v1_from_v2_example.yaml
@@ -1,23 +1,14 @@
-name: Amazon Elastic Compute Cloud
 documentation_complete: false
+name: Amazon Elastic Compute Cloud
 references:
 - name: Reference
   path: http://VerificationURL.com
   type: URL
-verifications:
-  EC2_Verification_1:
-    name: EC2 Verification 1
-    path: http://VerificationURL.com
-    type: URL
-  EC2_Verification_2:
-    name: EC2 Governor 2
-    path: artifact-ec2-1.png
-    type: Image
 satisfies:
   NIST-800-53:
     CM-2:
-      narrative: Justification in narrative form
       implementation_status: partial
+      narrative: Justification in narrative form
       refernces:
       - verification: EC2_Verification_1
       - component: UAA
@@ -25,8 +16,8 @@ satisfies:
         verification: UAA_Verification_1
   PCI-DSS-MAY-2015:
     1.1:
-      narrative: Justification in narrative form
       implementation_status: partial
+      narrative: Justification in narrative form
       refernces:
       - verification: EC2_Verification_1
       - component: UAA
@@ -38,3 +29,12 @@ satisfies:
     1.1.1:
       implementation_status: partial
       narrative: Justification in narrative form
+verifications:
+  EC2_Verification_1:
+    name: EC2 Verification 1
+    path: http://VerificationURL.com
+    type: URL
+  EC2_Verification_2:
+    name: EC2 Governor 2
+    path: artifact-ec2-1.png
+    type: Image

--- a/transformation-scripts/v1_from_v2_example.yaml
+++ b/transformation-scripts/v1_from_v2_example.yaml
@@ -1,0 +1,39 @@
+name: Amazon Elastic Compute Cloud
+references:
+- name: Reference
+  path: http://VerificationURL.com
+  type: URL
+satsifies:
+  NIST-800-53:
+    CM-2:
+      implementation_status: partial
+      narrative: Justification in narrative form
+      refernces:
+      - verification: EC2_Verification_1
+      - component: UAA
+        system: CloudFoundry
+        verification: UAA_Verification_1
+  PCI-DSS-MAY-2015:
+    1.1:
+      implementation_status: partial
+      narrative: Justification in narrative form
+      refernces:
+      - verification: EC2_Verification_1
+      - component: UAA
+        system: CloudFoundry
+        verification: UAA_Verification_1
+    2.1:
+      implementation_status: partial
+      narrative: Justification in narrative form
+    1.1.1:
+      implementation_status: partial
+      narrative: Justification in narrative form
+verifications:
+  EC2_Verification_1:
+    name: EC2 Verification 1
+    path: http://VerificationURL.com
+    type: URL
+  EC2_Verification_2:
+    name: EC2 Governor 2
+    path: artifact-ec2-1.png
+    type: Image

--- a/transformation-scripts/v1_from_v2_example.yaml
+++ b/transformation-scripts/v1_from_v2_example.yaml
@@ -1,13 +1,23 @@
 name: Amazon Elastic Compute Cloud
+documentation_complete: false
 references:
 - name: Reference
   path: http://VerificationURL.com
   type: URL
-satsifies:
+verifications:
+  EC2_Verification_1:
+    name: EC2 Verification 1
+    path: http://VerificationURL.com
+    type: URL
+  EC2_Verification_2:
+    name: EC2 Governor 2
+    path: artifact-ec2-1.png
+    type: Image
+satisfies:
   NIST-800-53:
     CM-2:
-      implementation_status: partial
       narrative: Justification in narrative form
+      implementation_status: partial
       refernces:
       - verification: EC2_Verification_1
       - component: UAA
@@ -15,8 +25,8 @@ satsifies:
         verification: UAA_Verification_1
   PCI-DSS-MAY-2015:
     1.1:
-      implementation_status: partial
       narrative: Justification in narrative form
+      implementation_status: partial
       refernces:
       - verification: EC2_Verification_1
       - component: UAA
@@ -28,12 +38,3 @@ satsifies:
     1.1.1:
       implementation_status: partial
       narrative: Justification in narrative form
-verifications:
-  EC2_Verification_1:
-    name: EC2 Verification 1
-    path: http://VerificationURL.com
-    type: URL
-  EC2_Verification_2:
-    name: EC2 Governor 2
-    path: artifact-ec2-1.png
-    type: Image

--- a/transformation-scripts/v1_to_v2.py
+++ b/transformation-scripts/v1_to_v2.py
@@ -1,19 +1,11 @@
+""" Python script to convert Open Controls schema version v1.0 to v2.0 """
+
 import yaml
+
+from utils import add_if_exists, transport_usable_data
 
 
 UNCHANGED_FIELDS = ['name', 'documentation_complete', 'references']
-
-
-def add_if_exists(new_data, old_data, field):
-    """ Adds the field to the new data if it exists in the old data """
-    if field in old_data:
-        new_data[field] = old_data.get(field)
-
-
-def transport_usable_data(new_data, old_data):
-    """ Adds the data structures that haven't changed to the new dictionary """
-    for field in UNCHANGED_FIELDS:
-        add_if_exists(new_data=new_data, old_data=old_data, field=field)
 
 
 def flatten_verifications(old_verifications):

--- a/transformation-scripts/v1_to_v2.py
+++ b/transformation-scripts/v1_to_v2.py
@@ -77,9 +77,9 @@ def convert(old_data):
     verifications = flatten_verifications(old_data.get('verifications', {}))
     if verifications:
         new_data['verifications'] = verifications
-    satsifies = convert_satsifies(old_data.get('satisfies', {}))
-    if satsifies:
-        new_data['satsifies'] = satsifies
+    satisfies = convert_satsifies(old_data.get('satisfies', {}))
+    if satisfies:
+        new_data['satisfies'] = satisfies
     return new_data
 
 

--- a/transformation-scripts/v1_to_v2.py
+++ b/transformation-scripts/v1_to_v2.py
@@ -1,0 +1,90 @@
+import yaml
+
+
+UNCHANGED_FIELDS = ['name', 'documentation_complete', 'references']
+
+
+def add_if_exists(new_data, old_data, field):
+    """ Adds the field to the new data if it exists in the old data """
+    field_value = old_data.get(field)
+    if field_value:
+        new_data[field] = field_value
+
+
+def transport_usable_data(new_data, old_data):
+    """ Adds the data structures that haven't changed to the new dictionary """
+    for field in UNCHANGED_FIELDS:
+        add_if_exists(new_data=new_data, old_data=old_data, field=field)
+
+
+def flatten_verifications(old_verifications):
+    """ Convert verifications from v1 to v2 """
+    new_verifications = []
+    for key in old_verifications:
+        verification = old_verifications[key]
+        verification['key'] = key
+        new_verifications.append(verification)
+    return new_verifications
+
+
+def transform_references(old_references):
+    """ Covert old reference format to new reference format """
+    new_references = []
+    for ref in old_references:
+        new_ref = {}
+        new_ref['verification_key'] = ref['verification']
+        component_key = ref.get('component')
+        system_key = ref.get('system')
+        if component_key:
+            new_ref['component_key'] = component_key
+        if system_key:
+            new_ref['system_key'] = system_key
+        new_references.append(new_ref)
+    return new_references
+
+
+def convert_satsifies(old_satsifies):
+    """ Convert satsifies objects from v1 to v2 """
+    new_satsifies = []
+    for standard_key in old_satsifies:
+        for control_key in old_satsifies[standard_key]:
+            new_control_dict = {
+                'standard_key': standard_key,
+                'control_key': control_key
+            }
+            old_control_dict = old_satsifies[standard_key][control_key]
+            add_if_exists(
+                new_data=new_control_dict,
+                old_data=old_control_dict,
+                field='narrative'
+            )
+            add_if_exists(
+                new_data=new_control_dict,
+                old_data=old_control_dict,
+                field='implementation_status'
+            )
+            new_control_dict['covered_by'] = transform_references(
+                old_control_dict.get('references', {})
+            )
+            new_satsifies.append(new_control_dict)
+    return new_satsifies
+
+
+def convert(old_data):
+    """ Convert the data from the v2 to v1 """
+    new_data = {}
+    transport_usable_data(new_data=new_data, old_data=old_data)
+    verifications = flatten_verifications(old_data.get('verifications', {}))
+    if verifications:
+        new_data['verifications'] = verifications
+    satsifies = convert_satsifies(old_data.get('satisfies', {}))
+    if satsifies:
+        new_data['satsifies'] = satsifies
+    return new_data
+
+
+if __name__ == '__main__':
+    data = yaml.load(open('v1_example.yaml'))
+    data = convert(data)
+    with open('v2_from_v1_example.yaml', 'w') as f:
+        f.write(yaml.dump(data, default_flow_style=False))

--- a/transformation-scripts/v1_to_v2.py
+++ b/transformation-scripts/v1_to_v2.py
@@ -5,9 +5,6 @@ import yaml
 from utils import add_if_exists, transport_usable_data
 
 
-UNCHANGED_FIELDS = ['name', 'documentation_complete', 'references']
-
-
 def flatten_verifications(old_verifications):
     """ Convert verifications from v1 to v2 """
     new_verifications = []
@@ -71,6 +68,8 @@ def convert(old_data):
     satisfies = convert_satisfies(old_data.get('satisfies', {}))
     if satisfies:
         new_data['satisfies'] = satisfies
+    # Tag new schema version
+    new_data['schema_version'] = 2.0
     return new_data
 
 

--- a/transformation-scripts/v1_to_v2.py
+++ b/transformation-scripts/v1_to_v2.py
@@ -6,9 +6,8 @@ UNCHANGED_FIELDS = ['name', 'documentation_complete', 'references']
 
 def add_if_exists(new_data, old_data, field):
     """ Adds the field to the new data if it exists in the old data """
-    field_value = old_data.get(field)
-    if field_value:
-        new_data[field] = field_value
+    if field in old_data:
+        new_data[field] = old_data.get(field)
 
 
 def transport_usable_data(new_data, old_data):
@@ -43,16 +42,16 @@ def transform_references(old_references):
     return new_references
 
 
-def convert_satsifies(old_satsifies):
-    """ Convert satsifies objects from v1 to v2 """
-    new_satsifies = []
-    for standard_key in old_satsifies:
-        for control_key in old_satsifies[standard_key]:
+def convert_satisfies(old_satisfies):
+    """ Convert satisfies objects from v1 to v2 """
+    new_satisfies = []
+    for standard_key in old_satisfies:
+        for control_key in old_satisfies[standard_key]:
             new_control_dict = {
                 'standard_key': standard_key,
                 'control_key': control_key
             }
-            old_control_dict = old_satsifies[standard_key][control_key]
+            old_control_dict = old_satisfies[standard_key][control_key]
             add_if_exists(
                 new_data=new_control_dict,
                 old_data=old_control_dict,
@@ -66,8 +65,8 @@ def convert_satsifies(old_satsifies):
             new_control_dict['covered_by'] = transform_references(
                 old_control_dict.get('references', {})
             )
-            new_satsifies.append(new_control_dict)
-    return new_satsifies
+            new_satisfies.append(new_control_dict)
+    return new_satisfies
 
 
 def convert(old_data):
@@ -77,7 +76,7 @@ def convert(old_data):
     verifications = flatten_verifications(old_data.get('verifications', {}))
     if verifications:
         new_data['verifications'] = verifications
-    satisfies = convert_satsifies(old_data.get('satisfies', {}))
+    satisfies = convert_satisfies(old_data.get('satisfies', {}))
     if satisfies:
         new_data['satisfies'] = satisfies
     return new_data

--- a/transformation-scripts/v2_example.yaml
+++ b/transformation-scripts/v2_example.yaml
@@ -1,0 +1,43 @@
+name: Amazon Elastic Compute Cloud
+references:
+- name: Reference
+  path: http://VerificationURL.com
+  type: URL
+satsifies:
+- control_key: CM-2
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
+  implementation_status: partial
+  narrative: Justification in narrative form
+  standard_key: NIST-800-53
+- control_key: 1.1
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
+  implementation_status: partial
+  narrative: Justification in narrative form
+  standard_key: PCI-DSS-MAY-2015
+- control_key: 2.1
+  covered_by: []
+  implementation_status: partial
+  narrative: Justification in narrative form
+  standard_key: PCI-DSS-MAY-2015
+- control_key: 1.1.1
+  covered_by: []
+  implementation_status: partial
+  narrative: Justification in narrative form
+  standard_key: PCI-DSS-MAY-2015
+verifications:
+- key: EC2_Verification_1
+  name: EC2 Verification 1
+  path: http://VerificationURL.com
+  type: URL
+- key: EC2_Verification_2
+  name: EC2 Governor 2
+  path: artifact-ec2-1.png
+  type: Image

--- a/transformation-scripts/v2_example.yaml
+++ b/transformation-scripts/v2_example.yaml
@@ -1,18 +1,15 @@
+documentation_complete: false
 name: Amazon Elastic Compute Cloud
 references:
 - name: Reference
   path: http://VerificationURL.com
   type: URL
-satsifies:
-- control_key: CM-2
-  covered_by:
-  - verification_key: EC2_Verification_1
-  - component_key: UAA
-    system_key: CloudFoundry
-    verification_key: UAA_Verification_1
+satisfies:
+- control_key: 1.1.1
+  covered_by: []
   implementation_status: partial
   narrative: Justification in narrative form
-  standard_key: NIST-800-53
+  standard_key: PCI-DSS-MAY-2015
 - control_key: 1.1
   covered_by:
   - verification_key: EC2_Verification_1
@@ -27,17 +24,21 @@ satsifies:
   implementation_status: partial
   narrative: Justification in narrative form
   standard_key: PCI-DSS-MAY-2015
-- control_key: 1.1.1
-  covered_by: []
+- control_key: CM-2
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
   implementation_status: partial
   narrative: Justification in narrative form
-  standard_key: PCI-DSS-MAY-2015
+  standard_key: NIST-800-53
 verifications:
-- key: EC2_Verification_1
-  name: EC2 Verification 1
-  path: http://VerificationURL.com
-  type: URL
 - key: EC2_Verification_2
   name: EC2 Governor 2
   path: artifact-ec2-1.png
   type: Image
+- key: EC2_Verification_1
+  name: EC2 Verification 1
+  path: http://VerificationURL.com
+  type: URL

--- a/transformation-scripts/v2_example.yaml
+++ b/transformation-scripts/v2_example.yaml
@@ -42,3 +42,4 @@ verifications:
   name: EC2 Verification 1
   path: http://VerificationURL.com
   type: URL
+schema_version: 2.0

--- a/transformation-scripts/v2_from_v1_example.yaml
+++ b/transformation-scripts/v2_from_v1_example.yaml
@@ -5,11 +5,15 @@ references:
   path: http://VerificationURL.com
   type: URL
 satisfies:
-- control_key: 1.1.1
-  covered_by: []
+- control_key: CM-2
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
   implementation_status: partial
   narrative: Justification in narrative form
-  standard_key: PCI-DSS-MAY-2015
+  standard_key: NIST-800-53
 - control_key: 1.1
   covered_by:
   - verification_key: EC2_Verification_1
@@ -24,15 +28,11 @@ satisfies:
   implementation_status: partial
   narrative: Justification in narrative form
   standard_key: PCI-DSS-MAY-2015
-- control_key: CM-2
-  covered_by:
-  - verification_key: EC2_Verification_1
-  - component_key: UAA
-    system_key: CloudFoundry
-    verification_key: UAA_Verification_1
+- control_key: 1.1.1
+  covered_by: []
   implementation_status: partial
   narrative: Justification in narrative form
-  standard_key: NIST-800-53
+  standard_key: PCI-DSS-MAY-2015
 verifications:
 - key: EC2_Verification_2
   name: EC2 Governor 2

--- a/transformation-scripts/v2_from_v1_example.yaml
+++ b/transformation-scripts/v2_from_v1_example.yaml
@@ -1,0 +1,43 @@
+name: Amazon Elastic Compute Cloud
+references:
+- name: Reference
+  path: http://VerificationURL.com
+  type: URL
+satsifies:
+- control_key: CM-2
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
+  implementation_status: partial
+  narrative: Justification in narrative form
+  standard_key: NIST-800-53
+- control_key: 1.1
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
+  implementation_status: partial
+  narrative: Justification in narrative form
+  standard_key: PCI-DSS-MAY-2015
+- control_key: 2.1
+  covered_by: []
+  implementation_status: partial
+  narrative: Justification in narrative form
+  standard_key: PCI-DSS-MAY-2015
+- control_key: 1.1.1
+  covered_by: []
+  implementation_status: partial
+  narrative: Justification in narrative form
+  standard_key: PCI-DSS-MAY-2015
+verifications:
+- key: EC2_Verification_1
+  name: EC2 Verification 1
+  path: http://VerificationURL.com
+  type: URL
+- key: EC2_Verification_2
+  name: EC2 Governor 2
+  path: artifact-ec2-1.png
+  type: Image

--- a/transformation-scripts/v2_from_v1_example.yaml
+++ b/transformation-scripts/v2_from_v1_example.yaml
@@ -1,18 +1,15 @@
+documentation_complete: false
 name: Amazon Elastic Compute Cloud
 references:
 - name: Reference
   path: http://VerificationURL.com
   type: URL
-satsifies:
-- control_key: CM-2
-  covered_by:
-  - verification_key: EC2_Verification_1
-  - component_key: UAA
-    system_key: CloudFoundry
-    verification_key: UAA_Verification_1
+satisfies:
+- control_key: 1.1.1
+  covered_by: []
   implementation_status: partial
   narrative: Justification in narrative form
-  standard_key: NIST-800-53
+  standard_key: PCI-DSS-MAY-2015
 - control_key: 1.1
   covered_by:
   - verification_key: EC2_Verification_1
@@ -27,17 +24,21 @@ satsifies:
   implementation_status: partial
   narrative: Justification in narrative form
   standard_key: PCI-DSS-MAY-2015
-- control_key: 1.1.1
-  covered_by: []
+- control_key: CM-2
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
   implementation_status: partial
   narrative: Justification in narrative form
-  standard_key: PCI-DSS-MAY-2015
+  standard_key: NIST-800-53
 verifications:
-- key: EC2_Verification_1
-  name: EC2 Verification 1
-  path: http://VerificationURL.com
-  type: URL
 - key: EC2_Verification_2
   name: EC2 Governor 2
   path: artifact-ec2-1.png
   type: Image
+- key: EC2_Verification_1
+  name: EC2 Verification 1
+  path: http://VerificationURL.com
+  type: URL

--- a/transformation-scripts/v2_from_v1_example.yaml
+++ b/transformation-scripts/v2_from_v1_example.yaml
@@ -33,6 +33,7 @@ satisfies:
   implementation_status: partial
   narrative: Justification in narrative form
   standard_key: PCI-DSS-MAY-2015
+schema_version: 2.0
 verifications:
 - key: EC2_Verification_2
   name: EC2 Governor 2

--- a/transformation-scripts/v2_to_v1.py
+++ b/transformation-scripts/v2_to_v1.py
@@ -1,0 +1,82 @@
+import yaml
+
+
+UNCHANGED_FIELDS = ['name', 'documentation_complete', 'references']
+
+
+def add_if_exists(new_data, old_data, field):
+    """ Adds the field to the new data if it exists in the old data """
+    field_value = old_data.get(field)
+    if field_value:
+        new_data[field] = field_value
+
+
+def transport_usable_data(new_data, old_data):
+    """ Adds the data structures that haven't changed to the new dictionary """
+    for field in UNCHANGED_FIELDS:
+        add_if_exists(new_data=new_data, old_data=old_data, field=field)
+
+
+def unflatten_verifications(old_verifications):
+    """ Convert verifications from v2 to v1 """
+    new_verifications = {}
+    for verification in old_verifications:
+        key = verification['key']
+        del verification['key']
+        new_verifications[key] = verification
+    return new_verifications
+
+
+def transform_covered_by(covered_by):
+    """ Transform covered_by to references as in version 1.0 """
+    new_references = []
+    for ref in covered_by:
+        new_ref = {}
+        new_ref['verification'] = ref['verification_key']
+        component_key = ref.get('component_key')
+        system_key = ref.get('system_key')
+        if component_key:
+            new_ref['component'] = component_key
+        if system_key:
+            new_ref['system'] = system_key
+        new_references.append(new_ref)
+    return new_references
+
+
+def unflatten_satsifies(old_satsifies):
+    """ Convert satsifies from v2 to v1 """
+    new_satsifies = {}
+    for element in old_satsifies:
+        new_element = {}
+        # Handle exsiting data
+        add_if_exists(new_data=new_element, old_data=element, field='narrative')
+        add_if_exists(new_data=new_element, old_data=element, field='implementation_status')
+        # Handle covered_by
+        refernces = transform_covered_by(element.get('covered_by', {}))
+        if refernces:
+            new_element['refernces'] = refernces
+        # Unflatten
+        if element['standard_key'] not in new_satsifies:
+            new_satsifies[element['standard_key']] = {}
+        if element['control_key'] not in new_satsifies[element['standard_key']]:
+             new_satsifies[element['standard_key']][element['control_key']] = new_element
+    return new_satsifies
+
+def convert(old_data):
+    """ Convert the data from the v2 to v1 """
+    new_data = {}
+    transport_usable_data(new_data=new_data, old_data=old_data)
+    verifications = unflatten_verifications(old_data.get('verifications', {}))
+    if verifications:
+        new_data['verifications'] = verifications
+    satsifies = unflatten_satsifies(old_data.get('satsifies', {}))
+    if satsifies:
+        new_data['satsifies'] = satsifies
+    return new_data
+
+
+if __name__ == '__main__':
+    data = yaml.load(open('v2_example.yaml'))
+    data = convert(data)
+    with open('v1_from_v2_example.yaml', 'w') as f:
+        f.write(yaml.dump(data, default_flow_style=False))

--- a/transformation-scripts/v2_to_v1.py
+++ b/transformation-scripts/v2_to_v1.py
@@ -1,19 +1,8 @@
+""" Python script to convert Open Controls schema version v2.0 to v1.0 """
+
 import yaml
 
-
-UNCHANGED_FIELDS = ['name', 'documentation_complete', 'references']
-
-
-def add_if_exists(new_data, old_data, field):
-    """ Adds the field to the new data if it exists in the old data """
-    if field in old_data:
-        new_data[field] = old_data.get(field)
-
-
-def transport_usable_data(new_data, old_data):
-    """ Adds the data structures that haven't changed to the new dictionary """
-    for field in UNCHANGED_FIELDS:
-        add_if_exists(new_data=new_data, old_data=old_data, field=field)
+from utils import add_if_exists, transport_usable_data
 
 
 def unflatten_verifications(old_verifications):
@@ -48,17 +37,27 @@ def unflatten_satisfies(old_satisfies):
     for element in old_satisfies:
         new_element = {}
         # Handle exsiting data
-        add_if_exists(new_data=new_element, old_data=element, field='narrative')
-        add_if_exists(new_data=new_element, old_data=element, field='implementation_status')
+        add_if_exists(
+            new_data=new_element,
+            old_data=element,
+            field='narrative'
+        )
+        add_if_exists(
+            new_data=new_element,
+            old_data=element,
+            field='implementation_status'
+        )
         # Handle covered_by
         refernces = transform_covered_by(element.get('covered_by', {}))
+        control_key = element['control_key']
+        standard_key = element['standard_key']
         if refernces:
             new_element['refernces'] = refernces
         # Unflatten
-        if element['standard_key'] not in new_satisfies:
-            new_satisfies[element['standard_key']] = {}
-        if element['control_key'] not in new_satisfies[element['standard_key']]:
-            new_satisfies[element['standard_key']][element['control_key']] = new_element
+        if standard_key not in new_satisfies:
+            new_satisfies[standard_key] = {}
+        if control_key not in new_satisfies[standard_key]:
+            new_satisfies[standard_key][control_key] = new_element
     return new_satisfies
 
 

--- a/transformation-scripts/v2_to_v1.py
+++ b/transformation-scripts/v2_to_v1.py
@@ -6,9 +6,8 @@ UNCHANGED_FIELDS = ['name', 'documentation_complete', 'references']
 
 def add_if_exists(new_data, old_data, field):
     """ Adds the field to the new data if it exists in the old data """
-    field_value = old_data.get(field)
-    if field_value:
-        new_data[field] = field_value
+    if field in old_data:
+        new_data[field] = old_data.get(field)
 
 
 def transport_usable_data(new_data, old_data):
@@ -43,10 +42,10 @@ def transform_covered_by(covered_by):
     return new_references
 
 
-def unflatten_satsifies(old_satsifies):
-    """ Convert satsifies from v2 to v1 """
-    new_satsifies = {}
-    for element in old_satsifies:
+def unflatten_satisfies(old_satisfies):
+    """ Convert satisfies from v2 to v1 """
+    new_satisfies = {}
+    for element in old_satisfies:
         new_element = {}
         # Handle exsiting data
         add_if_exists(new_data=new_element, old_data=element, field='narrative')
@@ -56,11 +55,12 @@ def unflatten_satsifies(old_satsifies):
         if refernces:
             new_element['refernces'] = refernces
         # Unflatten
-        if element['standard_key'] not in new_satsifies:
-            new_satsifies[element['standard_key']] = {}
-        if element['control_key'] not in new_satsifies[element['standard_key']]:
-             new_satsifies[element['standard_key']][element['control_key']] = new_element
-    return new_satsifies
+        if element['standard_key'] not in new_satisfies:
+            new_satisfies[element['standard_key']] = {}
+        if element['control_key'] not in new_satisfies[element['standard_key']]:
+            new_satisfies[element['standard_key']][element['control_key']] = new_element
+    return new_satisfies
+
 
 def convert(old_data):
     """ Convert the data from the v2 to v1 """
@@ -69,9 +69,9 @@ def convert(old_data):
     verifications = unflatten_verifications(old_data.get('verifications', {}))
     if verifications:
         new_data['verifications'] = verifications
-    satsifies = unflatten_satsifies(old_data.get('satsifies', {}))
-    if satsifies:
-        new_data['satsifies'] = satsifies
+    satisfies = unflatten_satisfies(old_data.get('satisfies', {}))
+    if satisfies:
+        new_data['satisfies'] = satisfies
     return new_data
 
 


### PR DESCRIPTION
Schema 1.0, although addressing multiple problems, is difficult to validate because it uses object keys as values. 

``` yaml
verifications:
  key_of_verification:
    - name: Name of verification
    - path: Relative path of local file or URL ie. diagrams/diagram-1.png
    - type: Type of reference ie. Image, URL
```

and

``` yaml
satisfies:
  NIST-800-53:
     CM-2:
     ...
```

The new schema flattens these sections:

``` yaml
verifications:
   - key: Key of Verification
   - name: Name of verification
   - path: Relative path of local file or URL ie. diagrams/diagram-1.png
   - type: Type of reference ie. Image, URL
```

and 

``` yaml
satisfies:
  - standard_key: NIST-800-53
  - control_key: CM-2
     ...
```

Additionally it introduces a `schema-version` tag to help tag the correct schema used in the docs. 

I still believe that this schema represents the correct approach for the internal data wrangling. But as a public facing schema that needs to be validated, it doesn't lend itself to validation easily. 

The schema in this PR flattens the object key - value hierarchies.
