### PR TITLE
support sematic versioning for schema_version

### DIFF
--- a/opencontrol-component-kwalify-schema.yaml
+++ b/opencontrol-component-kwalify-schema.yaml
@@ -9,7 +9,7 @@ mapping:
     type: str
     required: false
   schema_version:
-    type: number
+    type: any # V2 is a number, V3 is a string (semantic version)
     required: True
   documentation_complete:
     type: bool


### PR DESCRIPTION
First step for #14. This is needed to fix V3 Travis builds for our various Masonry YAML repositories.
