### PR TITLE
Add control_origin to schema validator

### DIFF
--- a/opencontrol-component-kwalify-schema.yaml
+++ b/opencontrol-component-kwalify-schema.yaml
@@ -62,6 +62,8 @@ mapping:
           narrative:
             type: any # should be string, but this added to support current docs
             required: True
+          control_origin:
+            type: str
           implementation_status:
             type: str
             enum:


### PR DESCRIPTION
Adds validation needed for users of this patch: https://github.com/opencontrol/compliance-masonry/pull/174
