### PR TITLE
Add parameters for schema validation

### DIFF
--- a/opencontrol-component-kwalify-schema.yaml
+++ b/opencontrol-component-kwalify-schema.yaml
@@ -64,6 +64,17 @@ mapping:
             required: True
           control_origin:
             type: str
+          parameters:
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  key:
+                    type: str
+                    required: True
+                  text:
+                    type: str
+                    required: True
           implementation_status:
             type: str
             enum:


### PR DESCRIPTION
Without this, it's blocking other PRs like this one which are using `parameters` field like this one: https://github.com/18F/cg-compliance/pull/91
