### PR TITLE
Remove control_origin from version 2.0.0

### DIFF
--- a/kwalify/component/v2.0.0.yaml
+++ b/kwalify/component/v2.0.0.yaml
@@ -62,8 +62,6 @@ mapping:
           narrative:
             type: str
             required: true
-          control_origin:
-            type: str
           parameters:
             type: seq
             sequence:


### PR DESCRIPTION
version 2.0.0 didn't have `control_origin` it was added in 3.0.0. This patch removes it.
We could make a version 2.1.0 if we really want to include it. @afeld 
