### PR TITLE
document Type in kwalify and in example per implementation.

### DIFF
--- a/examples/component_v3.0.0.yaml
+++ b/examples/component_v3.0.0.yaml
@@ -3,7 +3,6 @@ name: Amazon Elastic Compute Cloud
 references:
 - name: Reference
   path: http://VerificationURL.com
-  type: URL
 satisfies:
 - control_key: CM-2
   covered_by:
@@ -66,8 +65,6 @@ verifications:
 - key: EC2_Verification_2
   name: EC2 Governor 2
   path: artifact-ec2-1.png
-  type: Image
 - key: EC2_Verification_1
   name: EC2 Verification 1
   path: http://VerificationURL.com
-  type: URL

--- a/kwalify/component/v2.0.0.yaml
+++ b/kwalify/component/v2.0.0.yaml
@@ -25,6 +25,7 @@ mapping:
             type: str
           type:
             type: str
+            required: false
   verifications:
     type: seq
     sequence:
@@ -40,6 +41,7 @@ mapping:
             type: str
           type:
             type: str
+            required: true
           description:
             type: str
           test_passed:

--- a/kwalify/component/v2.0.0.yaml
+++ b/kwalify/component/v2.0.0.yaml
@@ -25,6 +25,9 @@ mapping:
             type: str
           type:
             type: str
+            enum:
+              - URL
+              - Image
             required: false
   verifications:
     type: seq
@@ -41,7 +44,10 @@ mapping:
             type: str
           type:
             type: str
-            required: true
+            enum:
+              - URL
+              - Image
+            required: false
           description:
             type: str
           test_passed:

--- a/kwalify/component/v2.0.0.yaml
+++ b/kwalify/component/v2.0.0.yaml
@@ -25,7 +25,6 @@ mapping:
             type: str
           type:
             type: str
-            required: true
   verifications:
     type: seq
     sequence:
@@ -41,7 +40,6 @@ mapping:
             type: str
           type:
             type: str
-            required: true
           description:
             type: str
           test_passed:

--- a/kwalify/component/v3.0.0.yaml
+++ b/kwalify/component/v3.0.0.yaml
@@ -27,7 +27,6 @@ mapping:
             type: str
           type:
             type: str
-            required: true
   verifications:
     type: seq
     sequence:
@@ -43,7 +42,6 @@ mapping:
             type: str
           type:
             type: str
-            required: true
           description:
             type: str
           test_passed:

--- a/kwalify/component/v3.0.0.yaml
+++ b/kwalify/component/v3.0.0.yaml
@@ -27,6 +27,9 @@ mapping:
             type: str
           type:
             type: str
+            enum:
+              - URL
+              - Image
             required: false
   verifications:
     type: seq
@@ -43,6 +46,9 @@ mapping:
             type: str
           type:
             type: str
+            enum:
+              - URL
+              - Image
             required: false
           description:
             type: str

--- a/kwalify/component/v3.0.0.yaml
+++ b/kwalify/component/v3.0.0.yaml
@@ -27,6 +27,7 @@ mapping:
             type: str
           type:
             type: str
+            required: false
   verifications:
     type: seq
     sequence:
@@ -42,6 +43,7 @@ mapping:
             type: str
           type:
             type: str
+            required: false
           description:
             type: str
           test_passed:

--- a/opencontrol-component-kwalify-schema.yaml
+++ b/opencontrol-component-kwalify-schema.yaml
@@ -26,6 +26,7 @@ mapping:
             type: str
           type:
             type: str
+            required: false
   verifications:
     type: seq
     sequence:
@@ -41,6 +42,7 @@ mapping:
             type: str
           type:
             type: str
+            required: false
           description:
             type: str
           test_passed:

--- a/opencontrol-component-kwalify-schema.yaml
+++ b/opencontrol-component-kwalify-schema.yaml
@@ -26,6 +26,9 @@ mapping:
             type: str
           type:
             type: str
+            enum:
+              - URL
+              - Image
             required: false
   verifications:
     type: seq
@@ -42,6 +45,9 @@ mapping:
             type: str
           type:
             type: str
+            enum:
+              - URL
+              - Image
             required: false
           description:
             type: str

--- a/opencontrol-component-kwalify-schema.yaml
+++ b/opencontrol-component-kwalify-schema.yaml
@@ -26,7 +26,6 @@ mapping:
             type: str
           type:
             type: str
-            required: true
   verifications:
     type: seq
     sequence:
@@ -42,7 +41,6 @@ mapping:
             type: str
           type:
             type: str
-            required: true
           description:
             type: str
           test_passed:


### PR DESCRIPTION
Ok, I've removed  'type' from the examples, but kept it in the kwalify schema, just as required false.

I look forward to seeing 'type:' have an implementation again, but having it required, and in the examples, when it has no effect, is a bit confusing.
