### PR TITLE
add pytest data validation test

### DIFF
--- a/kwalify/README.md
+++ b/kwalify/README.md
@@ -4,21 +4,28 @@ The files in the subdirectories of this folder are organized by the type of file
 
 ## Validation
 
-To validate your OpenControl files, use [the Kwalify command-line tool](http://www.kuwata-lab.com/kwalify/ruby/users-guide.05.html#ref-usage).
+To validate your OpenControl files, do the following from your project root directory:
 
-1. Install Kwalify (requires Ruby).
+1. Install Python (2 or 3).
+1. Ignore the `schemas/` directory from version control (e.g. `.gitignore`).
+1. Clone (or update) the [schemas](https://github.com/opencontrol/schemas) repository.
 
     ```bash
-    gem install kwalify
+    git clone https://github.com/opencontrol/schemas.git
+    # or
+    cd schemas && git pull origin master && cd ..
     ```
 
-1. Run the validation.
+1. Install the dependencies.
 
+    ```bash
+    pip install -r pip install -r schemas/kwalify/requirements.txt
     ```
-    $ kwalify -f kwalify/component/v3.0.0.yaml path/to/my/component.yaml
-    path/to/my/component.yaml#0: valid.
+
+1. Run the tests.
+
+    ```bash
+    pytest
     ```
 
-Note there is also [a Python port](https://github.com/Grokzen/pykwalify).
-
-For a more advanced setup, see [18F's cloud.gov compliance repository](https://github.com/18F/cg-compliance) as an example of using pykwalify as part of continuous integration.
+For a more advanced setup, see [18F's cloud.gov compliance repository](https://github.com/18F/cg-compliance) as an example of using these tests as part of continuous integration.

--- a/kwalify/component/test_data_validity.py
+++ b/kwalify/component/test_data_validity.py
@@ -8,7 +8,7 @@ def get_schema(version):
     return yaml.load(contents)
 
 def create_validator(source_data):
-    version = source_data.get('schema_version', '1.0.0')
+    version = source_data.get('schema_version', '3.1.0')
     schema = get_schema(version)
     validator = Core(source_data={}, schema_data=schema)
     validator.source = source_data
@@ -17,7 +17,6 @@ def create_validator(source_data):
 def test_data_valid():
     """ Check that the content of data fits with masonry schema v2 """
     for component_file in iglob('*/component.yaml'):
-        print(component_file)
         source_data = yaml.load(open(component_file))
         validator = create_validator(source_data)
         try:

--- a/kwalify/component/test_data_validity.py
+++ b/kwalify/component/test_data_validity.py
@@ -1,0 +1,26 @@
+from glob import iglob
+from pykwalify.core import Core
+import yaml
+
+def get_schema(version):
+    path = 'schemas/kwalify/component/v{}.yaml'.format(version)
+    contents = open(path)
+    return yaml.load(contents)
+
+def create_validator(source_data):
+    version = source_data.get('schema_version', '1.0.0')
+    schema = get_schema(version)
+    validator = Core(source_data={}, schema_data=schema)
+    validator.source = source_data
+    return validator
+
+def test_data_valid():
+    """ Check that the content of data fits with masonry schema v2 """
+    for component_file in iglob('*/component.yaml'):
+        print(component_file)
+        source_data = yaml.load(open(component_file))
+        validator = create_validator(source_data)
+        try:
+            validator.validate(raise_exception=True)
+        except:
+            assert False, "Error found in: {0}".format(component_file)

--- a/kwalify/requirements.txt
+++ b/kwalify/requirements.txt
@@ -1,0 +1,3 @@
+pykwalify~=1.5.1
+pytest~=3.0.0
+PyYAML~=3.11


### PR DESCRIPTION
Adapted from https://github.com/18F/cg-compliance/tree/821f5b72a9485ff8a25afdb744a925f20c1e7fb1, and broken out from https://github.com/18F/cg-compliance/pull/180. This way we can improve the tests in one place, and they can be easily leveraged by any OpenControl data repository.
## Follow-up TODOs
- [ ] Change cg-compliance (and other data repositories) to the tests from here
