### PR TITLE
Add schemas for standard and certification files.

### DIFF
--- a/kwalify/certification/v1.0.0.yaml
+++ b/kwalify/certification/v1.0.0.yaml
@@ -1,0 +1,12 @@
+type: map
+mapping:
+  standards:
+    type: map
+    mapping:
+      =:
+        type: map
+        mapping:
+          =:
+            type: any
+  name:
+    type: str

--- a/kwalify/standard/v1.0.0.yaml
+++ b/kwalify/standard/v1.0.0.yaml
@@ -7,6 +7,8 @@ mapping:
         type: str
       family:
         type: str
+      description:
+        type: str
 
   name:
     type: str

--- a/kwalify/standard/v1.0.0.yaml
+++ b/kwalify/standard/v1.0.0.yaml
@@ -1,0 +1,12 @@
+type: map
+mapping:
+  =:
+    type: map
+    mapping:
+      name:
+        type: str
+      family:
+        type: str
+
+  name:
+    type: str


### PR DESCRIPTION
Closes https://github.com/opencontrol/schemas/issues/54. Closes https://github.com/opencontrol/schemas/issues/55.

These have been checked on the NIST-800-53.yaml and FRIST-800-53.yaml
standards and the FredRAMP-low.yaml certification. Some of these
standards are currently seen as invalid yaml by kwalify; this is
independent of the schema.

They don't work with pykwalify yet; pykwalify doesn't seem to like the '=:' generic key matching rule. I'm looking into a way around this.
