### PR TITLE
Add optional "version" field to component schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Components represent individual parts of an application or organizational policy
 ```yaml
 name: Name of the component
 key: Key of the component (defaults to the filename if not present)
+version: Version of the component
 documentation_complete: Manual check if the documentation is complete (for gap analysis)
-schema_version: 3.0.0
+schema_version: 3.2.0
 references:
   - name: Name of the reference ie. EC2 website
     path: Relative path of local file or URL ie. diagrams/diagram-1.png

--- a/kwalify/component/v3.2.0.yaml
+++ b/kwalify/component/v3.2.0.yaml
@@ -1,0 +1,128 @@
+type: map
+mapping:
+  name:
+    type: str
+    required: true
+  key:
+    type: str
+  version:
+    type: str
+    required: false
+  system:
+    type: str
+    required: false
+  schema_version:
+    type: str
+    required: true
+  documentation_complete:
+    type: bool
+  responsible_role:
+    type: str
+  references:
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          name:
+            type: str
+            required: true
+          path:
+            type: str
+          type:
+            type: str
+            required: true
+  verifications:
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          key:
+            type: str
+            required: true
+          name:
+            type: str
+            required: true
+          path:
+            type: str
+          type:
+            type: str
+            required: true
+          description:
+            type: str
+          test_passed:
+            type: bool
+          last_run:
+            type: any
+  satisfies:
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          standard_key:
+            type: text
+            required: true
+          control_key:
+            type: text
+            required: true
+          narrative:
+            required: true
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  key:
+                    type: str
+                  text:
+                    type: str
+                    required: true
+          control_origin:
+            desc: |
+              This field will be deprectated in future versions of the schema.
+              Please use control_origins.
+            type: str
+          control_origins:
+            type: seq
+            sequence:
+              - type: str
+          parameters:
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  key:
+                    type: str
+                    required: true
+                  text:
+                    type: str
+                    required: true
+          implementation_status:
+            desc: |
+              This field will be deprectated in future versions of the schema.
+              Please use implementation_statuses.
+            type: str
+            enum:
+              - partial
+              - complete
+              - planned
+              - none
+          implementation_statuses:
+            type: seq
+            sequence:
+              - type: str
+                enum:
+                  - partial
+                  - complete
+                  - planned
+                  - none
+          covered_by:
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  system_key:
+                    type: str
+                  component_key:
+                    type: str
+                  verification_key:
+                    type: str
+                    required: true


### PR DESCRIPTION
Add optional "version" field as part of a minor version bump of the component schema. This allows one to denote a specific version of the component and also allows tools like compliance-masonry to easily parse the version of a component (for things like plugins, etc).

This should be an optional field since another way to separate component files by version could be to simply create subdirectories for each version of your component.