### PR TITLE
Add a "references" section in each "satisfies" entry

### DIFF
--- a/examples/component_v3.1.0.yaml
+++ b/examples/component_v3.1.0.yaml
@@ -1,77 +1,81 @@
 documentation_complete: false
 name: Amazon Elastic Compute Cloud
 references:
-- name: Reference
-  path: http://VerificationURL.com
-  type: URL
+  - name: Reference
+    path: http://VerificationURL.com
+    type: URL
 satisfies:
-- control_key: CM-2
-  covered_by:
-  - verification_key: EC2_Verification_1
-  - component_key: UAA
-    system_key: CloudFoundry
-    verification_key: UAA_Verification_1
-  implementation_statuses:
-    - partial
-    - planned
-  control_origins:
-    - shared
-    - inherited
-  narrative:
-    - key: "a"
-      text: "Justification in narrative form A for CM-2"
-    - key: "b"
-      text: "Justification in narrative form B for CM-2"
-  standard_key: NIST-800-53
-- control_key: 1.1
-  covered_by:
-  - verification_key: EC2_Verification_1
-  - component_key: UAA
-    system_key: CloudFoundry
-    verification_key: UAA_Verification_1
-  implementation_status: partial
-  control_origin: inherited
-  parameters:
-    - key: "a"
-      text: "Parameter A for 1.1"
-    - key: "b"
-      text: "Parameter B for 1.1"
-  narrative:
-    - key: "a"
-      text: "Justification in narrative form A for 1.1"
-    - key: "b"
-      text: "Justification in narrative form B for 1.1"
-  standard_key: PCI-DSS-MAY-2015
-- control_key: 1.1.1
-  covered_by: []
-  implementation_status: partial
-  control_origin: inherited
-  narrative:
-    - key: "a"
-      text: "Justification in narrative form A for 1.1.1"
-    - key: "b"
-      text: "Justification in narrative form B for 1.1.1"
-  parameters:
-    - key: "a"
-      text: "Parameter A for 1.1.1"
-    - key: "b"
-      text: "Parameter B for 1.1.1"
-  standard_key: PCI-DSS-MAY-2015
-- control_key: 2.1
-  covered_by: []
-  implementation_status: partial
-  control_origin: inherited
-  narrative:
-    - text: "Justification in narrative form for 2.1"
-  standard_key: PCI-DSS-MAY-2015
+  - control_key: CM-2
+    covered_by:
+      - verification_key: EC2_Verification_1
+      - component_key: UAA
+        system_key: CloudFoundry
+        verification_key: UAA_Verification_1
+    implementation_statuses:
+      - partial
+      - planned
+    control_origins:
+      - shared
+      - inherited
+    references:
+      - name: Reference2
+        path: http://VerificationURL2.com
+        type: URL
+    narrative:
+      - key: "a"
+        text: "Justification in narrative form A for CM-2"
+      - key: "b"
+        text: "Justification in narrative form B for CM-2"
+    standard_key: NIST-800-53
+  - control_key: 1.1
+    covered_by:
+      - verification_key: EC2_Verification_1
+      - component_key: UAA
+        system_key: CloudFoundry
+        verification_key: UAA_Verification_1
+    implementation_status: partial
+    control_origin: inherited
+    parameters:
+      - key: "a"
+        text: "Parameter A for 1.1"
+      - key: "b"
+        text: "Parameter B for 1.1"
+    narrative:
+      - key: "a"
+        text: "Justification in narrative form A for 1.1"
+      - key: "b"
+        text: "Justification in narrative form B for 1.1"
+    standard_key: PCI-DSS-MAY-2015
+  - control_key: 1.1.1
+    covered_by: []
+    implementation_status: partial
+    control_origin: inherited
+    narrative:
+      - key: "a"
+        text: "Justification in narrative form A for 1.1.1"
+      - key: "b"
+        text: "Justification in narrative form B for 1.1.1"
+    parameters:
+      - key: "a"
+        text: "Parameter A for 1.1.1"
+      - key: "b"
+        text: "Parameter B for 1.1.1"
+    standard_key: PCI-DSS-MAY-2015
+  - control_key: 2.1
+    covered_by: []
+    implementation_status: partial
+    control_origin: inherited
+    narrative:
+      - text: "Justification in narrative form for 2.1"
+    standard_key: PCI-DSS-MAY-2015
 responsible_role: "AWS Staff"
 schema_version: 3.0.0
 verifications:
-- key: EC2_Verification_2
-  name: EC2 Governor 2
-  path: artifact-ec2-1.png
-  type: Image
-- key: EC2_Verification_1
-  name: EC2 Verification 1
-  path: http://VerificationURL.com
-  type: URL
+  - key: EC2_Verification_2
+    name: EC2 Governor 2
+    path: artifact-ec2-1.png
+    type: Image
+  - key: EC2_Verification_1
+    name: EC2 Verification 1
+    path: http://VerificationURL.com
+    type: URL

--- a/kwalify/component/v3.1.0.yaml
+++ b/kwalify/component/v3.1.0.yaml
@@ -72,6 +72,19 @@ mapping:
                   text:
                     type: str
                     required: true
+          references:
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  name:
+                    type: str
+                    required: true
+                  path:
+                    type: str
+                  type:
+                    type: str
+                    required: true
           control_origin:
             desc: |
               This field will be deprectated in future versions of the schema.


### PR DESCRIPTION
Rather than only having a general list of references for the overall component, support references for each control that the component satisfies.  For components with broad feature sets, this will allow for more contextual references.

Fixes #64 

@anweiss, I matched the `references` structure from the top-level rather than your example in #64.  I suppose multiple `types` of reference will be supported by compliance-masonry.