### PR TITLE
Add contextdir for git directories into spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ dependencies:
       revision: master
 ```
 
+For version control systems, a option key `contextdir` can be specified to handle multiple opencontrol content directories in a single repository.
+For example:
+
+```
+dependencies:
+    - url: https://github.com/organization/repository
+      contextdir: subdirectory_in_repository
+      revision: branch
+```
+
 ### Validation
 
 ```bash

--- a/kwalify/opencontrol/v1.0.0.yaml
+++ b/kwalify/opencontrol/v1.0.0.yaml
@@ -39,6 +39,8 @@ mapping:
             mapping:
               url:
                 type: str
+              contextdir:
+                type: str
               revision:
                 type: str
       standards:
@@ -48,6 +50,8 @@ mapping:
             mapping:
               url:
                 type: str
+              contextdir:
+                type: str
               revision:
                 type: str
       systems:
@@ -56,6 +60,8 @@ mapping:
           - type: map
             mapping:
               url:
+                type: str
+              contextdir:
                 type: str
               revision:
                 type: str


### PR DESCRIPTION
This updates the opencontrol spec to allow specifying a source dir so that opencontrol content can exist in a single git repository.