### PR TITLE
Initial draft of component schema v3.2.0

### DIFF
--- a/kwalify/component/v3.2.0.yaml
+++ b/kwalify/component/v3.2.0.yaml
@@ -1,0 +1,124 @@
+type: map
+mapping:
+  name:
+    type: str
+    required: true
+  key:
+    type: str
+  system:
+    type: str
+    required: false
+  schema_version:
+    type: str
+    required: true
+  documentation_complete:
+    type: bool
+  responsible_role:
+    type: str
+  references:
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          name:
+            type: str
+            required: true
+          path:
+            type: str
+          type:
+            type: str
+            required: true
+  verifications:
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          key:
+            type: str
+            required: true
+          name:
+            type: str
+            required: true
+          path:
+            type: str
+          type:
+            type: str
+            required: true
+          description:
+            type: str
+          test_passed:
+            type: bool
+          last_run:
+            type: any
+  satisfies:
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          standard_key:
+            type: text
+            required: true
+          control_key:
+            type: text
+            required: true
+          narrative:
+            required: true
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  key:
+                    type: str
+                  text:
+                    type: str
+                    required: true
+          references:
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  name:
+                    type: str
+                    required: true
+                  path:
+                    type: str
+                  type:
+                    type: str
+                    required: true
+          control_origins:
+            type: seq
+            sequence:
+              - type: str
+          parameters:
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  key:
+                    type: str
+                    required: true
+                  text:
+                    type: str
+                    required: true
+          implementation_statuses:
+            type: seq
+            sequence:
+              - type: str
+                enum:
+                  - partial
+                  - complete
+                  - planned
+                  - none
+                  - not applicable
+          covered_by:
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  system_key:
+                    type: str
+                  component_key:
+                    type: str
+                  verification_key:
+                    type: str
+                    required: true


### PR DESCRIPTION
Wanting to add a new implementation_status of ``not applicable``. Wasn't sure if this should be done in existing schema vs creating an increment.

To start the conversation, created v.3.2.0 which:
- Adds new ``not applicable`` status
- Deprecates ``control_origin``
- Deprecates ``implementation_status``